### PR TITLE
Handle HTTPForbidden errors which break polling loop

### DIFF
--- a/src/aiohubspace/v1/controllers/event.py
+++ b/src/aiohubspace/v1/controllers/event.py
@@ -8,6 +8,7 @@ from types import NoneType
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from aiohttp.client_exceptions import ClientError
+from aiohttp.web_exceptions import HTTPForbidden
 
 from ..device import HubspaceDevice, get_hs_device
 
@@ -182,7 +183,11 @@ class EventStream:
                         )
                     )
                     processed_ids.append(hs_dev.id)
-            except (ClientError, asyncio.TimeoutError) as err:  # pragma: no cover
+            except (
+                ClientError,
+                asyncio.TimeoutError,
+                HTTPForbidden,
+            ) as err:  # pragma: no cover
                 # Auto-retry will take care of the issue
                 self._logger.warning(err)
             except asyncio.CancelledError:  # pragma: no cover


### PR DESCRIPTION
403 errors were getting caught by a catch-all handler and getting re-thrown, which ended the polling loop. I added a test case to confirm the loop was exiting and then added an explicit catch for HTTPForbidden exceptions.

Here is the error:
![image](https://github.com/user-attachments/assets/6ddc2ece-df6c-42a9-863e-a896ec1c6361)