### PR TITLE
Handle all HttpErrors and add backoff logic

### DIFF
--- a/src/aiohubspace/v1/controllers/event.py
+++ b/src/aiohubspace/v1/controllers/event.py
@@ -8,7 +8,7 @@ from types import NoneType
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from aiohttp.client_exceptions import ClientError
-from aiohttp.web_exceptions import HTTPForbidden
+from aiohttp.web_exceptions import HTTPError
 
 from ..device import HubspaceDevice, get_hs_device
 
@@ -162,11 +162,13 @@ class EventStream:
     async def __event_reader(self) -> None:
         """Poll the current states"""
         self._status = EventStreamStatus.CONNECTING
+        consecutive_http_errors = 0
         while True:
             processed_ids = []
             skipped_ids = []
             try:
                 data = await self._bridge.fetch_data()
+                consecutive_http_errors = 0
                 self._status = EventStreamStatus.CONNECTED
                 for dev in data:
                     hs_dev = get_hs_device(dev)
@@ -183,13 +185,17 @@ class EventStream:
                         )
                     )
                     processed_ids.append(hs_dev.id)
-            except (
-                ClientError,
-                asyncio.TimeoutError,
-                HTTPForbidden,
-            ) as err:  # pragma: no cover
+            except (ClientError, asyncio.TimeoutError) as err:  # pragma: no cover
                 # Auto-retry will take care of the issue
                 self._logger.warning(err)
+            except HTTPError as err:
+                self._logger.warning(err)
+                consecutive_http_errors += 1
+                backoff_time = min(consecutive_http_errors * self.polling_interval, 600)
+                self._logger.warning(
+                    f"Backing off... Waiting {backoff_time} seconds before next poll."
+                )
+                await asyncio.sleep(backoff_time)
             except asyncio.CancelledError:  # pragma: no cover
                 self._logger.info("Shutting down event reader")
                 break

--- a/src/aiohubspace/v1/controllers/event.py
+++ b/src/aiohubspace/v1/controllers/event.py
@@ -191,7 +191,6 @@ class EventStream:
                 # Auto-retry will take care of the issue
                 self._logger.warning(err)
             except (HTTPForbidden, HTTPTooManyRequests) as err:
-                self._logger.warning(err)
                 consecutive_http_errors += 1
                 backoff_time = min(consecutive_http_errors * self.polling_interval, 600)
                 debug_message = (

--- a/tests/v1/controllers/test_event.py
+++ b/tests/v1/controllers/test_event.py
@@ -2,7 +2,7 @@ import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
-from aiohttp.web_exceptions import HTTPForbidden, HTTPServerError, HTTPTooManyRequests
+from aiohttp.web_exceptions import HTTPForbidden, HTTPTooManyRequests
 
 from aiohubspace.v1.controllers import event
 from aiohubspace.v1.models.resource import ResourceTypes

--- a/tests/v1/controllers/test_event.py
+++ b/tests/v1/controllers/test_event.py
@@ -105,14 +105,13 @@ async def test_event_reader_dev_add(bridge, mocker):
 
 
 @pytest.mark.asyncio
-async def test_event_reader_httperror_should_continue(bridge, mocker):
+async def test_event_reader_http_errors_should_continue(bridge, mocker):
     stream = bridge.events
     stream.polling_interval = 0.2
     await stream.stop()
 
     def side_effect_fetch():
         yield HTTPForbidden()
-        yield HTTPServerError()
         yield HTTPTooManyRequests()
         while True:
             yield []


### PR DESCRIPTION
Figured it makes sense to handle all HttpErrors with status codes in the 400s or 500s with this new backoff logic....

This should keep the polling loop alive through backoffs, intermittent API issues, intermittent network issues, etc.

Let me know if you think any of these HttpErrors should actually be handled separately.



